### PR TITLE
fix access openai.Embedding no longer supported in openai>=1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas
 neo4j
-openai
+openai==0.28
 python-dotenv


### PR DESCRIPTION
I have followed the tutorial to build a vector index for my Neo4j instance using OpenAI version 1.42.0.
However, during the embedding process(`openai_embeddings.py`), I encountered the following message:

> You tried to access openai.Embedding, but this is no longer supported in openai>=1.0.0 - see the README at https://github.com/openai/openai-python for the API.
> You can run `openai migrate` to automatically upgrade your codebase to use the 1.0.0 interface. 
> Alternatively, you can pin your installation to the old version, e.g. `pip install openai==0.28`

![image](https://github.com/user-attachments/assets/d39190d8-89a6-4353-9827-36100dd5f803)
![image](https://github.com/user-attachments/assets/968002e4-85ec-4905-bcfd-392baaf98898)

I downgraded my OpenAI version to 0.28, which resolved the issue.